### PR TITLE
reset visible tooltip list before setting new one

### DIFF
--- a/coachmark/src/main/java/com/pseudoankit/coachmark/scope/CoachMarkScopeImpl.kt
+++ b/coachmark/src/main/java/com/pseudoankit/coachmark/scope/CoachMarkScopeImpl.kt
@@ -30,6 +30,8 @@ internal class CoachMarkScopeImpl(
 
     private var _visibleTooltips = listOf<TooltipConfig>()
         set(value) {
+            // resetting all values before setting new ones
+            field = listOf()
             _visibleTooltipIndex = 0
             updateVisibleItem(value, _visibleTooltipIndex)
             field = value


### PR DESCRIPTION
Issue : https://github.com/pseudoankit/coachmark/issues/14

Reason - Once coachmarks are displayed I was setting last and current visible to null
but not `_visibleTooltips` and when user wants to show new coachmarks
I was setting `_visibleTooltipIndex` to 0 and setter of this variable was again assigning last coachmark's 0th item to current and next iteration was setting it to last visible

Solution - rest `_visibleTooltips` once we are setting up new values
