### PR TITLE
Add support for centrally places tooltips (screen center)

### DIFF
--- a/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/demo/UnifyCoachmarkDemo.kt
+++ b/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/demo/UnifyCoachmarkDemo.kt
@@ -24,7 +24,7 @@ import com.pseudoankit.coachmark.shape.Arrow
 import com.pseudoankit.coachmark.shape.Balloon
 import com.pseudoankit.coachmark.util.CoachMarkKey
 
-public enum class Keys { Text1, Text2, TextStart, TextBottom, TextTop }
+public enum class Keys { Text1, Text2, TextCenter, TextStart, TextBottom, TextTop }
 
 
 @Composable
@@ -83,6 +83,18 @@ private fun ColumnScope.PlotTextsAndUseLocalCoachMarkScope() {
         alignment = Alignment.Start,
         key = Keys.Text2,
         placement = ToolTipPlacement.End
+    )
+
+    CoachMarkTargetText(
+        text = "Will show tooltip centrally",
+        alignment = Alignment.CenterHorizontally,
+        key = Keys.TextCenter,
+        placement = ToolTipPlacement.ScreenCenter,
+        tooltip = {
+            Balloon(arrow = Arrow.Top()) {
+                Text(text = "tooltip on screen center at enableCoachmark method", color = Color.White)
+            }
+        }
     )
 
     CoachMarkTargetText(
@@ -153,6 +165,12 @@ private fun Tooltip(key: CoachMarkKey) {
         Keys.Text2 -> {
             Balloon(arrow = Arrow.Start()) {
                 Text(text = "Highlighting Text2  root level", color = Color.White)
+            }
+        }
+
+        Keys.TextCenter -> {
+            Balloon(arrow = Arrow.Top()) {
+                Text(text = "A tooltip on screen center root level", color = Color.White)
             }
         }
 

--- a/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/model/ToolTipPlacement.kt
+++ b/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/model/ToolTipPlacement.kt
@@ -26,5 +26,11 @@ public enum class ToolTipPlacement {
     /**
      * denotes that tooltip will be placed at bottom of actual view
      */
-    Bottom
+    Bottom,
+
+    /**
+     * denotes that tooltip will be placed at the center of the screen, regardless of the actual view.
+     */
+    ScreenCenter
+
 }

--- a/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/overlay/OverlayLayout.kt
+++ b/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/overlay/OverlayLayout.kt
@@ -129,7 +129,8 @@ private fun measure(
  * @param containerHeight the height of the container overlay
  */
 private fun Placeable.PlacementScope.place(
-    placeable: Placeable?, config: TooltipConfig?,
+    placeable: Placeable?,
+    config: TooltipConfig?,
     containerWidth: Int,
     containerHeight: Int
 ) {

--- a/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/overlay/OverlayLayout.kt
+++ b/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/overlay/OverlayLayout.kt
@@ -62,8 +62,8 @@ public fun OverlayLayout(
 
         // place children
         layout(constraints.maxWidth, constraints.maxHeight) {
-            place(placeableCurrent, configCurrent)
-            place(placeablePrevious, configPrevious)
+            place(placeableCurrent, configCurrent, constraints.maxWidth, constraints.maxHeight)
+            place(placeablePrevious, configPrevious, constraints.maxWidth, constraints.maxHeight)
         }
     }
 }
@@ -125,8 +125,14 @@ private fun measure(
  * Centralizes null checks and switching on toolTipPlacement value.
  * @param placeable no-op if null
  * @param config no-op if null
+ * @param containerWidth the width of the container overlay
+ * @param containerHeight the height of the container overlay
  */
-private fun Placeable.PlacementScope.place(placeable: Placeable?, config: TooltipConfig?) {
+private fun Placeable.PlacementScope.place(
+    placeable: Placeable?, config: TooltipConfig?,
+    containerWidth: Int,
+    containerHeight: Int
+) {
     if (placeable != null && config != null) {
         val layout = config.layout
         var x = 0
@@ -141,6 +147,10 @@ private fun Placeable.PlacementScope.place(placeable: Placeable?, config: Toolti
 
         fun centerHorizontally() =
             (layout.startX + calculateCenteringOffset(layout.width, placeable.width)).toInt()
+
+        fun centerVerticallyToScreen() = (containerHeight - placeable.height) / 2
+
+        fun centerHorizontallyToScreen() = (containerWidth - placeable.width) / 2
 
         when (config.toolTipPlacement) {
             ToolTipPlacement.Start -> {
@@ -161,6 +171,11 @@ private fun Placeable.PlacementScope.place(placeable: Placeable?, config: Toolti
             ToolTipPlacement.Bottom -> {
                 x = centerHorizontally()
                 y = layout.endY.toInt()
+            }
+
+            ToolTipPlacement.ScreenCenter -> {
+                x = centerHorizontallyToScreen()
+                y = centerVerticallyToScreen()
             }
         }
 


### PR DESCRIPTION
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/91543e0a-f333-4aab-b789-136ecc07af7b" />

Used to create tours that have popup dialog style, with central tips, example:
<img width="344" height="443" alt="image" src="https://github.com/user-attachments/assets/e76983e5-8445-40b6-a349-33c6e58bae6c" />
