### PR TITLE
added option not to highlight the view, only tip to be shown

### DIFF
--- a/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/model/HighlightedViewConfig.kt
+++ b/coachmark/src/commonMain/kotlin/com/pseudoankit/coachmark/model/HighlightedViewConfig.kt
@@ -53,5 +53,15 @@ public data class HighlightedViewConfig(
                 )
             }
         }
+
+        /**
+         * Shape that doesn't highlight the view in any way.
+         */
+        public object None : Shape {
+            override fun pathToHighlight(
+                density: Density,
+                size: Size
+            ): Path = Path()
+        }
     }
 }


### PR DESCRIPTION
added option not to highlight the view, only tip to be shown.
Can be useful for any tip (top / bottom / left / fight) where we don't really like to highlight the view, just show the tip.
Also useful for centrally shown tips that are visually not attached to any view.
Example: Tour start tip / Tour end tip.